### PR TITLE
Enable multi-platform streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # stream-to-shorts
 
-A minimal system for monitoring Twitch streams and creating short clips. This
-repository provides a simple skeleton with pluggable modules. It is **not** a
-fully featured production system but serves as a starting point for further
-development.
+A minimal system for monitoring live streams and creating short clips. The
+project started with Twitch support and now exposes a small abstraction layer so
+additional platforms can be plugged in easily. It is **not** a fully featured
+production system but serves as a starting point for further development.
 
 ## Setup
 
@@ -13,8 +13,9 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
-Edit `config/default.yml` with your Twitch API credentials and desired
-streamers.
+Edit `config/default.yml` with your API credentials and desired streamers. Each
+stream entry can specify a ``platform`` (``twitch`` or ``youtube``) and a
+``username`` or channel ID.
 
 ## Running
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,8 +1,11 @@
 # Example configuration for stream-to-shorts
 
 streams:
-  - username: example_streamer
+  - platform: twitch
+    username: example_streamer
     quality: best
+  # - platform: youtube
+  #   username: UCxxxxxx  # channel ID
 
 storage:
   recordings: recordings/

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from .stream_monitor import StreamMonitor
+from .stream_monitor import TwitchStreamMonitor, YouTubeStreamMonitor
 from .stream_recorder import StreamRecorder
 from .content_manager import ContentManager
 from .scheduler import Scheduler
@@ -13,11 +13,18 @@ logging.basicConfig(level=logging.INFO)
 
 
 def main() -> None:
-    monitor = StreamMonitor(client_id="YOUR_CLIENT_ID", oauth_token="YOUR_TOKEN")
+    twitch_monitor = TwitchStreamMonitor(
+        client_id="YOUR_CLIENT_ID", oauth_token="YOUR_TOKEN"
+    )
+    # Example: add a YouTube monitor
+    # youtube_monitor = YouTubeStreamMonitor(api_key="YOUR_API_KEY")
+
     recorder = StreamRecorder()
     manager = ContentManager(Path("data.db"))
-    sched = Scheduler(monitor, recorder, manager)
-    sched.start(["example_streamer"])  # replace with desired streamers
+    sched = Scheduler(recorder, manager)
+    sched.add_monitor(twitch_monitor, ["example_streamer"])  # replace with Twitch streamers
+    # sched.add_monitor(youtube_monitor, ["CHANNEL_ID"])  # add YouTube channels
+    sched.start()
 
 
 if __name__ == "__main__":

--- a/src/platform_registry.py
+++ b/src/platform_registry.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+"""Registry for streaming platform monitors."""
+
+from typing import Dict, Type
+
+from .stream_monitor import (
+    BaseStreamMonitor,
+    TwitchStreamMonitor,
+    YouTubeStreamMonitor,
+)
+
+PLATFORMS: Dict[str, Type[BaseStreamMonitor]] = {
+    "twitch": TwitchStreamMonitor,
+    "youtube": YouTubeStreamMonitor,
+}
+
+
+def get_monitor(platform: str, **kwargs) -> BaseStreamMonitor:
+    """Return a monitor instance for the given platform."""
+    monitor_cls = PLATFORMS.get(platform.lower())
+    if monitor_cls is None:
+        raise ValueError(f"Unsupported platform: {platform}")
+    return monitor_cls(**kwargs)

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -2,30 +2,35 @@
 from __future__ import annotations
 
 import logging
-from typing import List
+from typing import Dict, List
 
 from apscheduler.schedulers.background import BackgroundScheduler
 
-from .stream_monitor import StreamMonitor
+from .stream_monitor import BaseStreamMonitor, StreamMonitor
 from .stream_recorder import RecordingConfig, StreamRecorder
 from .content_manager import ContentManager
 
 
 class Scheduler:
-    def __init__(self, monitor: StreamMonitor, recorder: StreamRecorder, manager: ContentManager) -> None:
+    def __init__(self, recorder: StreamRecorder, manager: ContentManager) -> None:
         self.logger = logging.getLogger(self.__class__.__name__)
-        self.monitor = monitor
         self.recorder = recorder
         self.manager = manager
+        self.monitors: Dict[BaseStreamMonitor, List[str]] = {}
         self.sched = BackgroundScheduler()
 
-    def start(self, users: List[str], interval: int = 60) -> None:
+    def add_monitor(self, monitor: BaseStreamMonitor, users: List[str]) -> None:
+        """Register a monitor with the scheduler."""
+        self.monitors[monitor] = users
+
+    def start(self, interval: int = 60) -> None:
         self.logger.info("Starting scheduler")
-        self.sched.add_job(lambda: self.check_streams(users), 'interval', seconds=interval)
+        self.sched.add_job(self.check_streams, 'interval', seconds=interval)
         self.sched.start()
 
-    def check_streams(self, users: List[str]) -> None:
-        streams = self.monitor.get_live_streams(users)
-        for stream in streams:
-            path = self.recorder.record(RecordingConfig(url=stream.url))
-            self.manager.add_stream(stream.streamer, stream.title, path)
+    def check_streams(self) -> None:
+        for monitor, users in self.monitors.items():
+            streams = monitor.get_live_streams(users)
+            for stream in streams:
+                path = self.recorder.record(RecordingConfig(url=stream.url))
+                self.manager.add_stream(stream.streamer, stream.title, path)

--- a/src/stream_monitor.py
+++ b/src/stream_monitor.py
@@ -1,9 +1,16 @@
-"""Twitch stream monitoring utilities."""
+"""Stream monitoring utilities.
+
+This module now provides a small abstraction layer that makes it possible to
+support multiple streaming platforms.  The original Twitch specific monitor is
+kept for backwards compatibility and a basic YouTube implementation is
+included as an example.  Additional platforms can be added by creating new
+classes that implement :class:`BaseStreamMonitor`.
+"""
 from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import List, Dict, Optional
+from typing import Dict, List, Optional, Protocol
 
 import requests
 
@@ -19,7 +26,14 @@ class StreamInfo:
     url: str
 
 
-class StreamMonitor:
+class BaseStreamMonitor(Protocol):
+    """Interface for a streaming platform monitor."""
+
+    def get_live_streams(self, user_logins: List[str]) -> List[StreamInfo]:
+        """Return metadata for live streams from a list of usernames."""
+
+
+class TwitchStreamMonitor:
     """Monitor Twitch for live streams."""
 
     def __init__(self, client_id: str, oauth_token: str) -> None:
@@ -35,10 +49,11 @@ class StreamMonitor:
         }
 
     def get_live_streams(self, user_logins: List[str]) -> List[StreamInfo]:
-        """Return metadata for live streams from a list of usernames."""
         params = [("user_login", login) for login in user_logins]
         self.logger.debug("Fetching live streams for %s", user_logins)
-        resp = requests.get(self.base_url, headers=self._headers(), params=params, timeout=10)
+        resp = requests.get(
+            self.base_url, headers=self._headers(), params=params, timeout=10
+        )
         resp.raise_for_status()
         data = resp.json().get("data", [])
         streams = []
@@ -53,3 +68,45 @@ class StreamMonitor:
                 )
             )
         return streams
+
+
+class YouTubeStreamMonitor:
+    """Basic YouTube live stream monitor using the Data API."""
+
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+        self.base_url = "https://www.googleapis.com/youtube/v3/search"
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    def get_live_streams(self, channel_ids: List[str]) -> List[StreamInfo]:
+        streams = []
+        for cid in channel_ids:
+            params = {
+                "part": "snippet",
+                "channelId": cid,
+                "type": "video",
+                "eventType": "live",
+                "key": self.api_key,
+            }
+            self.logger.debug("Fetching live streams for channel %s", cid)
+            resp = requests.get(self.base_url, params=params, timeout=10)
+            resp.raise_for_status()
+            items = resp.json().get("items", [])
+            for item in items:
+                snippet = item.get("snippet", {})
+                streams.append(
+                    StreamInfo(
+                        streamer=snippet.get("channelTitle", cid),
+                        title=snippet.get("title"),
+                        game=None,
+                        viewer_count=0,
+                        url=f"https://www.youtube.com/watch?v={item['id']['videoId']}",
+                    )
+                )
+        return streams
+
+
+# Backwards compatibility: previously the Twitch implementation was named
+# ``StreamMonitor``.  Export the Twitch monitor under that name so existing
+# imports continue to work.
+StreamMonitor = TwitchStreamMonitor

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -11,6 +11,7 @@ MODULES = [
     'src.video_editor',
     'src.content_manager',
     'src.scheduler',
+    'src.platform_registry',
 ]
 
 def test_imports():


### PR DESCRIPTION
## Summary
- support multiple platforms by abstracting stream monitoring
- provide Twitch and YouTube monitor implementations
- add registry for available platforms
- update scheduler to handle multiple monitors
- document new configuration options

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856c53d4368833091c09e167bfb8150