### PR TITLE
Add configurable credentials and stream settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
-Edit `config/default.yml` with your API credentials and desired streamers. Each
-stream entry can specify a ``platform`` (``twitch`` or ``youtube``) and a
-``username`` or channel ID.
+Edit `config/default.yml` with your API credentials and desired streamers.
+Credentials are defined under the ``credentials`` section and individual
+streams specify a ``platform`` (``twitch`` or ``youtube``), a ``username`` or
+channel ID and an optional ``quality`` setting.
 
 ## Running
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,11 +1,19 @@
 # Example configuration for stream-to-shorts
 
+credentials:
+  twitch:
+    client_id: YOUR_CLIENT_ID
+    oauth_token: YOUR_TOKEN
+  # youtube:
+  #   api_key: YOUR_API_KEY
+
 streams:
   - platform: twitch
     username: example_streamer
     quality: best
   # - platform: youtube
   #   username: UCxxxxxx  # channel ID
+  #   quality: best
 
 storage:
   recordings: recordings/

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -8,24 +8,45 @@ from .stream_monitor import TwitchStreamMonitor, YouTubeStreamMonitor
 from .stream_recorder import StreamRecorder
 from .content_manager import ContentManager
 from .scheduler import Scheduler
+from .config_loader import load_config
 
 logging.basicConfig(level=logging.INFO)
 
 
-def main() -> None:
-    twitch_monitor = TwitchStreamMonitor(
-        client_id="YOUR_CLIENT_ID", oauth_token="YOUR_TOKEN"
-    )
-    # Example: add a YouTube monitor
-    # youtube_monitor = YouTubeStreamMonitor(api_key="YOUR_API_KEY")
+def main(config_path: str = "config/default.yml") -> None:
+    """Run the stream monitoring pipeline using the given config file."""
+
+    cfg = load_config(Path(config_path))
 
     recorder = StreamRecorder()
-    manager = ContentManager(Path("data.db"))
-    sched = Scheduler(recorder, manager)
-    sched.add_monitor(twitch_monitor, ["example_streamer"])  # replace with Twitch streamers
-    # sched.add_monitor(youtube_monitor, ["CHANNEL_ID"])  # add YouTube channels
-    sched.start()
+    manager = ContentManager(Path(cfg.storage.get("database", "data.db")))
+    sched = Scheduler(recorder, manager, Path(cfg.storage.get("recordings", "recordings")))
+
+    monitors = {}
+    creds = cfg.credentials
+    twitch_creds = creds.get("twitch")
+    if twitch_creds:
+        monitors["twitch"] = TwitchStreamMonitor(
+            client_id=twitch_creds["client_id"],
+            oauth_token=twitch_creds["oauth_token"],
+        )
+    youtube_creds = creds.get("youtube")
+    if youtube_creds:
+        monitors["youtube"] = YouTubeStreamMonitor(api_key=youtube_creds["api_key"])
+
+    for stream in cfg.streams:
+        platform = stream.get("platform")
+        username = stream.get("username")
+        quality = stream.get("quality", "best")
+        monitor = monitors.get(platform)
+        if monitor is None:
+            logging.warning("No credentials configured for platform %s", platform)
+            continue
+        sched.add_stream(monitor, username, quality)
+
+    sched.start(cfg.scheduler.get("interval", 60))
 
 
 if __name__ == "__main__":
     main()
+

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+"""Utilities for loading application configuration."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List
+
+import yaml
+
+
+@dataclass
+class Config:
+    """Container for application configuration."""
+
+    streams: List[Dict[str, Any]]
+    storage: Dict[str, Any]
+    scheduler: Dict[str, Any]
+    credentials: Dict[str, Dict[str, str]]
+
+
+def load_config(path: Path) -> Config:
+    """Load configuration from a YAML file."""
+    with path.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    return Config(
+        streams=data.get("streams", []),
+        storage=data.get("storage", {}),
+        scheduler=data.get("scheduler", {}),
+        credentials=data.get("credentials", {}),
+    )

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Dict, List
 
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -11,26 +13,45 @@ from .stream_recorder import RecordingConfig, StreamRecorder
 from .content_manager import ContentManager
 
 
+@dataclass
+class StreamSpec:
+    """Specification for a stream to monitor."""
+
+    username: str
+    quality: str = "best"
+
+
 class Scheduler:
-    def __init__(self, recorder: StreamRecorder, manager: ContentManager) -> None:
+    def __init__(self, recorder: StreamRecorder, manager: ContentManager, output_dir: Path) -> None:
         self.logger = logging.getLogger(self.__class__.__name__)
         self.recorder = recorder
         self.manager = manager
-        self.monitors: Dict[BaseStreamMonitor, List[str]] = {}
+        self.output_dir = output_dir
+        self.monitors: Dict[BaseStreamMonitor, List[StreamSpec]] = {}
         self.sched = BackgroundScheduler()
 
-    def add_monitor(self, monitor: BaseStreamMonitor, users: List[str]) -> None:
-        """Register a monitor with the scheduler."""
-        self.monitors[monitor] = users
+    def add_stream(self, monitor: BaseStreamMonitor, username: str, quality: str = "best") -> None:
+        """Register a stream with the scheduler."""
+        specs = self.monitors.setdefault(monitor, [])
+        specs.append(StreamSpec(username=username, quality=quality))
 
     def start(self, interval: int = 60) -> None:
         self.logger.info("Starting scheduler")
-        self.sched.add_job(self.check_streams, 'interval', seconds=interval)
+        self.sched.add_job(self.check_streams, "interval", seconds=interval)
         self.sched.start()
 
     def check_streams(self) -> None:
-        for monitor, users in self.monitors.items():
-            streams = monitor.get_live_streams(users)
+        for monitor, specs in self.monitors.items():
+            usernames = [s.username for s in specs]
+            streams = monitor.get_live_streams(usernames)
+            spec_map = {s.username: s for s in specs}
             for stream in streams:
-                path = self.recorder.record(RecordingConfig(url=stream.url))
+                spec = spec_map.get(stream.streamer)
+                cfg = RecordingConfig(
+                    url=stream.url,
+                    quality=spec.quality if spec else "best",
+                    output=self.output_dir,
+                )
+                path = self.recorder.record(cfg)
                 self.manager.add_stream(stream.streamer, stream.title, path)
+


### PR DESCRIPTION
## Summary
- load configuration from YAML
- allow providing Twitch/YouTube credentials via config
- store stream recording settings in config
- update scheduler to handle per-stream settings and output path
- document new configuration format

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856c7bf0e98833092e2c5fd96118d63